### PR TITLE
get rid of deprecated case alias

### DIFF
--- a/regex-dsl.el
+++ b/regex-dsl.el
@@ -135,7 +135,7 @@
 	  chars))
 
 (defun redsl-to-regexp-rec (re)
-  (case (car re)
+  (cl-case (car re)
     (group
      (format "\\(?:%s\\)" (redsl-to-regexp-rec (cadr re))))
     (cap-group


### PR DESCRIPTION
Small change to get rid of the annoying warning message about the deprecated `case` function.